### PR TITLE
Add `include` to indexes for Active Record 7.1

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -5,6 +5,7 @@
 ENV["RAILS_ENV"] ||= "development"
 
 require "bundler/setup"
+require "logger"
 require "combustion"
 
 Combustion.path = "spec/dummy"

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -332,6 +332,7 @@ module PgParty
         index_definition.unique ? 'UNIQUE' : index_definition.type,
         index_columns,
         index_definition.where ? " WHERE #{index_definition.where}" : nil,
+        index_definition.include ? "INCLUDE (#{index_definition.include.join(', ')})" : nil
         add_index_options_result.second, # algorithm option
         index_definition.using ? "USING #{index_definition.using}" : nil
       ]

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -338,11 +338,13 @@ module PgParty
     end
 
     def index_options(index_definition)
-      return nil if index_definition.include.blank? && index_definition.where.blank?
+      return unless index_definition.respond_to?(:include) || index_definition.where
 
-      include_sql = index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : ''
-      where_sql = index_definition.where ? " WHERE #{index_definition.where}" : ''
-      "#{include_sql} #{where_sql}",
+      index_includes = index_definition.respond_to?(:include) ? index_definition.include : nil
+      include_options = index_includes && index_definition.using != :hash ? " INCLUDE (#{index_includes.join(', ')})" : ''
+      where_options = index_definition.where ? " WHERE #{index_definition.where}" : ''
+
+      "#{include_options}#{where_options}"
     end
 
     def drop_indices_if_exist(index_names)

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -340,7 +340,9 @@ module PgParty
     def index_options(index_definition)
       return nil if index_definition.include.blank? && index_definition.where.blank?
 
-      "#{index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : ''} #{index_definition.where ? " WHERE #{index_definition.where}" : ''}",
+      include_sql = index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : ''
+      where_sql = index_definition.where ? " WHERE #{index_definition.where}" : ''
+      "#{include_sql} #{where_sql}",
     end
 
     def drop_indices_if_exist(index_names)

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -331,8 +331,8 @@ module PgParty
         index_definition.name,
         index_definition.unique ? 'UNIQUE' : index_definition.type,
         index_columns,
-        index_definition.where ? " WHERE #{index_definition.where}" : nil,
         index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : nil,
+        index_definition.where ? " WHERE #{index_definition.where}" : nil,
         add_index_options_result.second, # algorithm option
         index_definition.using ? "USING #{index_definition.using}" : nil
       ]

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -331,8 +331,7 @@ module PgParty
         index_definition.name,
         index_definition.unique ? 'UNIQUE' : index_definition.type,
         index_columns,
-        index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : nil,
-        index_definition.where ? " WHERE #{index_definition.where}" : nil,
+        "#{index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : ''} #{index_definition.where ? " WHERE #{index_definition.where}" : ''}",
         add_index_options_result.second, # algorithm option
         index_definition.using ? "USING #{index_definition.using}" : nil
       ]

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -332,7 +332,7 @@ module PgParty
         index_definition.unique ? 'UNIQUE' : index_definition.type,
         index_columns,
         index_definition.where ? " WHERE #{index_definition.where}" : nil,
-        index_definition.include ? "INCLUDE (#{index_definition.include.join(', ')})" : nil
+        index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : nil,
         add_index_options_result.second, # algorithm option
         index_definition.using ? "USING #{index_definition.using}" : nil
       ]

--- a/lib/pg_party/adapter_decorator.rb
+++ b/lib/pg_party/adapter_decorator.rb
@@ -331,10 +331,16 @@ module PgParty
         index_definition.name,
         index_definition.unique ? 'UNIQUE' : index_definition.type,
         index_columns,
-        "#{index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : ''} #{index_definition.where ? " WHERE #{index_definition.where}" : ''}",
+        index_options(index_definition),
         add_index_options_result.second, # algorithm option
         index_definition.using ? "USING #{index_definition.using}" : nil
       ]
+    end
+
+    def index_options(index_definition)
+      return nil if index_definition.include.blank? && index_definition.where.blank?
+
+      "#{index_definition.include ? " INCLUDE (#{index_definition.include.join(', ')})" : ''} #{index_definition.where ? " WHERE #{index_definition.where}" : ''}",
     end
 
     def drop_indices_if_exist(index_names)

--- a/pg_party.gemspec
+++ b/pg_party.gemspec
@@ -27,6 +27,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "appraisal", "~> 2.2"
   spec.add_development_dependency "byebug", "~> 11.0"
+  spec.add_development_dependency "base64", "~> 0.2.0"
+  spec.add_development_dependency "bigdecimal", "~> 3.1"
+  spec.add_development_dependency "mutex_m", "~> 0.3.0"
+  spec.add_development_dependency "drb", "~> 2.2"
   spec.add_development_dependency "combustion", "~> 1.3"
   spec.add_development_dependency "nokogiri", ">= 1.10.4", "< 2.0"
   spec.add_development_dependency "pry-byebug", "~> 3.7"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 ENV["RAILS_ENV"] ||= "test"
 
+require "logger"
 require "combustion"
 require "timecop"
 require "pry-byebug"


### PR DESCRIPTION
This will allow anyone using Active Record 7.1+ to be able to use the `include` keyword when creating indexes